### PR TITLE
Filter option for Tooltips: current character only

### DIFF
--- a/InventoryTools/InventoryToolsConfiguration.cs
+++ b/InventoryTools/InventoryToolsConfiguration.cs
@@ -83,6 +83,7 @@ namespace InventoryTools
         public int SelectedConfigurationPage { get; set; }
         public bool ShowFilterTab { get; set; } = true;
         public bool SwitchFiltersAutomatically { get; set; } = true;
+        private bool _tooltipCurrentCharacter = false;
         private bool _tooltipDisplayAmountOwned = true;
         private bool _tooltipDisplayMarketAveragePrice = true;
         private bool _tooltipDisplayMarketLowestPrice = false;
@@ -143,6 +144,16 @@ namespace InventoryTools
             set
             {
                 _displayTooltip = value;
+                ConfigurationChanged?.Invoke();
+            }
+        }
+
+        public bool TooltipCurrentCharacter
+        {
+            get => _tooltipCurrentCharacter;
+            set
+            {
+                _tooltipCurrentCharacter = value;
                 ConfigurationChanged?.Invoke();
             }
         }

--- a/InventoryTools/Logic/Settings/TooltipCurrentCharacterOnly.cs
+++ b/InventoryTools/Logic/Settings/TooltipCurrentCharacterOnly.cs
@@ -1,0 +1,28 @@
+using InventoryTools.Logic.Settings.Abstract;
+
+namespace InventoryTools.Logic.Settings
+{
+    public class TooltipCurrentCharacterSetting : BooleanSetting
+    {
+        public override bool DefaultValue { get; set; } = false;
+        
+        public override bool CurrentValue(InventoryToolsConfiguration configuration)
+        {
+            return configuration.TooltipCurrentCharacter;
+        }
+
+        public override void UpdateFilterConfiguration(InventoryToolsConfiguration configuration, bool newValue)
+        {
+            configuration.TooltipCurrentCharacter = newValue;
+        }
+
+        public override string Key { get; set; } = "TooltipCurrentCharacter";
+        public override string Name { get; set; } = "Limit to items belonging to the current character?";
+
+        public override string HelpText { get; set; } =
+            "Limits the information displayed on the tooltip to inventories belonging to the currently logged in character.";
+
+        public override SettingCategory SettingCategory { get; set; } = SettingCategory.Visuals;
+        public override SettingSubCategory SettingSubCategory { get; } = SettingSubCategory.Tooltips;
+    }
+}

--- a/InventoryTools/PluginLogic.cs
+++ b/InventoryTools/PluginLogic.cs
@@ -623,9 +623,13 @@ namespace InventoryTools
                     List<string> locations = new List<string>();
                     foreach (var oItem in ownedItems)
                     {
-                        storageCount += oItem.Quantity;
                         if (PluginService.CharacterMonitor.Characters.ContainsKey(oItem.RetainerId))
                         {
+                            if (PluginConfiguration.TooltipCurrentCharacter && !PluginService.CharacterMonitor.BelongsToActiveCharacter(oItem.RetainerId))
+                                continue;
+
+                            storageCount += oItem.Quantity;
+
                             var characterMonitorCharacter = PluginService.CharacterMonitor.Characters[oItem.RetainerId];
                             var name = characterMonitorCharacter?.FormattedName ?? "Unknown";
                             name = name.Trim().Length == 0 ? "Unknown" : name.Trim();


### PR DESCRIPTION
Adds an option to limit the information displayed on item tooltips to the just the inventories belonging to current character.


Hey!  Hope this is considered a good idea, first contribution to a plugin.

I've left the default to off to preserve current behaviour, I imagine it's quite useful for those that have alts for storage, but I find the behaviour quite annoying when having alts for other reasons, especially with crafting.

One thing I am a bit confused about, with InventoryTools/PluginLogic.cs Line 626, I had to move this inside the loop, on the items I checked with it made sense, but then I wonder, is there a time when the conditional would be false?  Would my skip make sense prior to Line 626 instead?