### PR TITLE
Update Dependency XivCommon

### DIFF
--- a/InventoryTools/InventoryTools.csproj
+++ b/InventoryTools/InventoryTools.csproj
@@ -30,7 +30,7 @@
         <PackageReference Include="DalamudPackager" Version="2.1.7" />
         <PackageReference Include="SerialQueue" Version="2.1.0" />
         <PackageReference Include="System.Reactive" Version="5.0.0" />
-        <PackageReference Include="XivCommon" Version="6.0.0" />
+        <PackageReference Include="XivCommon" Version="6.0.2" />
         <ProjectReference Include="..\CriticalCommonLib\CriticalCommonLib.csproj" />
         <ProjectReference Include="..\OtterGui\OtterGui.csproj" />
         <ProjectReference Include="..\Tetris\Tetris.csproj" />

--- a/InventoryTools/packages.lock.json
+++ b/InventoryTools/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "XivCommon": {
         "type": "Direct",
-        "requested": "[6.0.0, )",
-        "resolved": "6.0.0",
-        "contentHash": "8HwrC7mnkcaP+JxRoIIu9MqFElQRVL8HOr8EQ6Te+11zzvKoXTZZrZ7VWETF2CHfB+7c1v5wONZKqZJ2hETpjg=="
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "C/GnQ61iO0yEpf8LPixU3tCThar1MWUiBkO8gdZHNtVskg8AvFeuIxk7Zmkf2yeAJ0drR/KOTdSS7GpbsgmoaQ=="
       },
       "NaturalSort.Extension": {
         "type": "Transitive",


### PR DESCRIPTION
Get's rid of the warnings in log. Helps reduce confusion on game updates