### PR TITLE
New IPC methods "GetRetrievalItems" and "GetSearchFilters"

### DIFF
--- a/InventoryTools/IPC/IPCService.cs
+++ b/InventoryTools/IPC/IPCService.cs
@@ -33,7 +33,7 @@ public class IPCService : IDisposable
     private readonly ICallGateProvider<string, uint, uint, bool>? _removeItemFromCraftList;
     private readonly ICallGateProvider<string, Dictionary<uint, uint>>? _getFilterItems;
     private readonly ICallGateProvider<string, Dictionary<uint, uint>>? _getCraftItems;
-    private readonly ICallGateProvider<string, Dictionary<uint, uint>>? _getRetrievalItems;
+    private readonly ICallGateProvider<Dictionary<uint, uint>>? _getRetrievalItems;
     private readonly ICallGateProvider<ulong, HashSet<ulong[]>> _getCharacterItems;
     private readonly ICallGateProvider<bool, HashSet<ulong>> _getCharactersOwnedByActive;
     private readonly ICallGateProvider<ulong, uint, HashSet<ulong[]>> _getCharacterItemsByType;
@@ -113,7 +113,7 @@ public class IPCService : IDisposable
         _getCraftItems = pluginInterface.GetIpcProvider<string, Dictionary<uint, uint>>("AllaganTools.GetCraftItems");
         _getCraftItems.RegisterFunc(GetCraftItems);
 
-        _getRetrievalItems = pluginInterface.GetIpcProvider<string, Dictionary<uint, uint>>("AllaganTools.GetRetrievalItems");
+        _getRetrievalItems = pluginInterface.GetIpcProvider<Dictionary<uint, uint>>("AllaganTools.GetRetrievalItems");
         _getRetrievalItems.RegisterFunc(GetRetrievalItems);
 
         _getCharacterItems = pluginInterface.GetIpcProvider<ulong, HashSet<ulong[]>>("AllaganTools.GetCharacterItems");
@@ -271,9 +271,9 @@ public class IPCService : IDisposable
         return craftItems;
     }
 
-    private Dictionary<uint, uint> GetRetrievalItems(string filterKey)
+    private Dictionary<uint, uint> GetRetrievalItems()
     {
-        var filter = _filterService.GetFilterByKeyOrName(filterKey);
+        var filter = _filterService.GetActiveCraftList();
         var retrievalItems = new Dictionary<uint, uint>();
 
         if (filter != null && filter.FilterType == FilterType.CraftFilter)

--- a/InventoryTools/IPC/IPCService.cs
+++ b/InventoryTools/IPC/IPCService.cs
@@ -278,15 +278,15 @@ public class IPCService : IDisposable
 
         if (filter != null && filter.FilterType == FilterType.CraftFilter)
         {
-            foreach (var craftItem in filter.CraftList.CraftItems)
+            foreach (((var itemId, _), var quantity) in filter.CraftList.GetQuantityToRetrieveList())
             {
-                if (craftItem.QuantityWillRetrieve > 0) {
-                    if (retrievalItems.ContainsKey(craftItem.ItemId))
-                    {
-                        retrievalItems[craftItem.ItemId] += craftItem.QuantityWillRetrieve;
-                    } else {
-                        retrievalItems.Add(craftItem.ItemId, craftItem.QuantityWillRetrieve);
-                    }
+                if (quantity == 0) continue;
+
+                if (retrievalItems.ContainsKey(itemId))
+                {
+                    retrievalItems[itemId] += quantity;
+                } else {
+                    retrievalItems.Add(itemId, quantity);
                 }
             }
         }


### PR DESCRIPTION
Working on a toy plugin to ease retainer inventory juggling that would benefit from these methods. Usecases:

1. I have a set of filters, one for each retainer, to figure out where to entrust my items. I'd like to automatically highlight the relevant filter when I open a retainer's inventory, which requires me to specify which search filter corresponds with which retainer. `GetSearchFilters` helps with that.
2. The craft list shows which items I need to retrieve and how many, but not which retainer they're in and not in any particular order. When I want to avoid withdrawing more items than I'm going to use, this requires a lot of cross-referencing between the Retrieval section in the crafting list and the inventory I'm looking at, which is cumbersome with long lists that have lots of retrieval items. With `GetRetrievalItems` I can automatically cross reference that list with the items in the inventory I'm looking at which will let me draw a little overlay with a number or something.