### PR TITLE
WIP: 206 : Alternative tooltip separator

### DIFF
--- a/InventoryTools/InventoryToolsConfiguration.cs
+++ b/InventoryTools/InventoryToolsConfiguration.cs
@@ -364,6 +364,8 @@ namespace InventoryTools
         private WindowLayout _craftWindowLayout =  WindowLayout.Tabs;
         private WindowLayout _filtersLayout = WindowLayout.Tabs;
         private uint? _tooltipColor;
+        private bool _tooltipSeparator;
+        private bool _tooltipSeparatorGlobalEnable;
         private HashSet<NotificationPopup>? _notificationsSeen = new ();
 
         [Vector4Default("0.007, 0.008,0.007, 0.212")]
@@ -820,6 +822,26 @@ namespace InventoryTools
         {
             get => _tooltipColor;
             set => _tooltipColor = value;
+        }
+        
+        public bool TooltipSeparator
+        {
+            get => _tooltipSeparator;
+            set
+            {
+                _tooltipSeparator = value;
+                IsDirty = true;
+            }
+        }
+        
+        public bool TooltipSeparatorGlobalEnable
+        {
+            get => _tooltipSeparatorGlobalEnable;
+            set
+            {
+                _tooltipSeparatorGlobalEnable = value;
+                IsDirty = true;
+            }
         }
 
         public ModifiableHotkey? MoreInformationHotKey

--- a/InventoryTools/Logic/Settings/Abstract/Generic/GenericSeparatorSetting.cs
+++ b/InventoryTools/Logic/Settings/Abstract/Generic/GenericSeparatorSetting.cs
@@ -1,0 +1,46 @@
+using InventoryTools.Services;
+using Microsoft.Extensions.Logging;
+
+namespace InventoryTools.Logic.Settings.Abstract.Generic;
+
+public abstract class GenericSeparatorSetting : BooleanSetting
+{
+    public GenericSeparatorSetting(
+        string key,
+        string name,
+        string helpText,
+        bool? defaultValue,
+        SettingCategory settingCategory,
+        SettingSubCategory settingSubCategory,
+        string version, 
+        ILogger logger, 
+        ImGuiService imGuiService
+        ) : base(logger, imGuiService)
+    {
+        Key = key;
+        Name = name;
+        HelpText = helpText;
+        DefaultValue = defaultValue ?? false;
+        SettingCategory = settingCategory;
+        SettingSubCategory = settingSubCategory;
+        Version = version;
+    }
+    
+    public override bool DefaultValue { get; set; } = false;
+    public override bool CurrentValue(InventoryToolsConfiguration configuration)
+    {
+        return configuration.TooltipSeparator;
+    }
+
+    public override void UpdateFilterConfiguration(InventoryToolsConfiguration configuration, bool newValue)
+    {
+        configuration.TooltipSeparator = newValue;
+    }
+
+    public override string Key { get; set; }
+    public override string Name { get; set; }
+    public override string HelpText { get; set; }
+    public override SettingCategory SettingCategory { get; set; }
+    public override SettingSubCategory SettingSubCategory { get; }
+    public override string Version { get; }
+}

--- a/InventoryTools/Logic/Settings/TooltipAmountOwnedSeparatorSetting.cs
+++ b/InventoryTools/Logic/Settings/TooltipAmountOwnedSeparatorSetting.cs
@@ -1,0 +1,23 @@
+using InventoryTools.Logic.Settings.Abstract;
+using InventoryTools.Logic.Settings.Abstract.Generic;
+using InventoryTools.Services;
+using Microsoft.Extensions.Logging;
+
+namespace InventoryTools.Logic.Settings;
+
+public class TooltipAmountOwnedSeparatorSetting : GenericSeparatorSetting
+{
+    public TooltipAmountOwnedSeparatorSetting(ILogger<TooltipAmountOwnedSeparatorSetting> logger, ImGuiService imGuiService) : base(
+        "TooltipSeparator",
+        "Add separator",
+        "Add separator",
+        false,
+        SettingCategory.ToolTips,
+        SettingSubCategory.AddItemLocations,
+        "1.7.0.21",
+        logger,
+        imGuiService
+    )
+    {
+    }
+}

--- a/InventoryTools/Logic/Settings/TooltipGlobalSeparatorSetting.cs
+++ b/InventoryTools/Logic/Settings/TooltipGlobalSeparatorSetting.cs
@@ -1,0 +1,34 @@
+using InventoryTools.Logic.Settings.Abstract;
+using InventoryTools.Logic.Settings.Abstract.Generic;
+using InventoryTools.Services;
+using Microsoft.Extensions.Logging;
+
+namespace InventoryTools.Logic.Settings
+{
+    public class TooltipGlobalSeparatorSetting : GenericSeparatorSetting
+    {
+        public TooltipGlobalSeparatorSetting(ILogger<TooltipGlobalSeparatorSetting> logger, ImGuiService imGuiService) : base(
+            "TooltipSeparatorGlobal",
+            "Enable separator ?",
+            "Add separator in header and footer",
+            false,
+            SettingCategory.ToolTips,
+            SettingSubCategory.General,
+            "1.7.0.21",
+            logger,
+            imGuiService
+        )
+        {
+        }
+        
+        public override bool CurrentValue(InventoryToolsConfiguration configuration)
+        {
+            return configuration.TooltipSeparatorGlobalEnable;
+        }
+        
+        public override void UpdateFilterConfiguration(InventoryToolsConfiguration configuration, bool newValue)
+        {
+            configuration.TooltipSeparatorGlobalEnable = newValue;
+        }
+    }
+}

--- a/InventoryTools/Tooltips/AmountOwnedTooltip.cs
+++ b/InventoryTools/Tooltips/AmountOwnedTooltip.cs
@@ -34,7 +34,6 @@ public class AmountOwnedTooltip : BaseTooltip
         _itemLocalizer = itemLocalizer;
     }
     private const string indentation = "      ";
-    private const string separator = "──────────────────────────\n";
 
     public override bool IsEnabled => Configuration.DisplayTooltip && Configuration.TooltipDisplayAmountOwned;
     public override unsafe void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData)
@@ -253,7 +252,6 @@ public class AmountOwnedTooltip : BaseTooltip
 
             if (storageCount > 0)
             {
-                textLines.Add($"{separator}");
                 textLines.Add($"Owned: {storageCount}\n");
                 textLines.Add($"Locations:\n");
                 for (var index = 0; index < locations.Count; index++)
@@ -261,10 +259,9 @@ public class AmountOwnedTooltip : BaseTooltip
                     var location = locations[index];
                     textLines.Add($"{indentation}{location}\n");
                 }
-                textLines.Add($"{separator}");
             }
 
-            var newText = "\n";
+            var newText = Configuration.TooltipSeparatorGlobalEnable ? "" : "\n";
             if (textLines.Count != 0)
             {
                 for (var index = 0; index < textLines.Count; index++)

--- a/InventoryTools/Tooltips/AmountOwnedTooltip.cs
+++ b/InventoryTools/Tooltips/AmountOwnedTooltip.cs
@@ -34,6 +34,7 @@ public class AmountOwnedTooltip : BaseTooltip
         _itemLocalizer = itemLocalizer;
     }
     private const string indentation = "      ";
+    private const string separator = "──────────────────────────\n";
 
     public override bool IsEnabled => Configuration.DisplayTooltip && Configuration.TooltipDisplayAmountOwned;
     public override unsafe void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData)
@@ -252,6 +253,7 @@ public class AmountOwnedTooltip : BaseTooltip
 
             if (storageCount > 0)
             {
+                textLines.Add($"{separator}");
                 textLines.Add($"Owned: {storageCount}\n");
                 textLines.Add($"Locations:\n");
                 for (var index = 0; index < locations.Count; index++)
@@ -259,6 +261,7 @@ public class AmountOwnedTooltip : BaseTooltip
                     var location = locations[index];
                     textLines.Add($"{indentation}{location}\n");
                 }
+                textLines.Add($"{separator}");
             }
 
             var newText = "\n";

--- a/InventoryTools/Tooltips/BaseTooltip.cs
+++ b/InventoryTools/Tooltips/BaseTooltip.cs
@@ -13,6 +13,7 @@ namespace InventoryTools.Tooltips;
 
 public abstract class BaseTooltip : TooltipService.TooltipTweak, IDisposable
 {
+    public const string separator = "\n──────────────────────────\n";
     public InventoryToolsConfiguration Configuration { get; }
     public IGameGui GameGui { get; }
 

--- a/InventoryTools/Tooltips/FooterTextTooltip.cs
+++ b/InventoryTools/Tooltips/FooterTextTooltip.cs
@@ -18,7 +18,9 @@ public class FooterTextTooltip : BaseTooltip
     {
     }
     public override bool IsEnabled =>
-        Configuration.DisplayTooltip && Configuration.TooltipFooterLines != 0;
+        Configuration.DisplayTooltip 
+        && 
+        (Configuration.TooltipFooterLines != 0 || Configuration.TooltipSeparatorGlobalEnable);
 
     public override unsafe void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData)
     {
@@ -69,6 +71,11 @@ public class FooterTextTooltip : BaseTooltip
                     {
                         newText += "\n";
                     }
+                }
+                
+                if (Configuration.TooltipSeparatorGlobalEnable)
+                {
+                    newText += $"{separator}";
                 }
 
                 if (newText != "")

--- a/InventoryTools/Tooltips/HeaderTextTooltip.cs
+++ b/InventoryTools/Tooltips/HeaderTextTooltip.cs
@@ -18,8 +18,12 @@ public class HeaderTextTooltip : BaseTooltip
     {
     }
     public override bool IsEnabled =>
-        Configuration.DisplayTooltip && (Configuration.TooltipHeaderLines != 0 ||
-                                         Configuration.TooltipDisplayHeader);
+        Configuration.DisplayTooltip 
+        && (
+            Configuration.TooltipHeaderLines != 0 ||
+            Configuration.TooltipDisplayHeader ||
+            Configuration.TooltipSeparatorGlobalEnable
+            );
 
     public override unsafe void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData)
     {
@@ -75,6 +79,11 @@ public class HeaderTextTooltip : BaseTooltip
                 if (Configuration.TooltipDisplayHeader)
                 {
                     newText += "\n[Allagan Tools]";
+                }
+                
+                if (Configuration.TooltipSeparatorGlobalEnable)
+                {
+                    newText = $"{separator}" +  newText;
                 }
 
                 if (newText != "")


### PR DESCRIPTION
Idea for responding to the issue : https://github.com/Critical-Impact/InventoryTools/issues/206

I haven't figured out how to determine the width of the object description window, so I suggest this solution, knowing that it's not great.
I'm not familiar with this project or how it works, so there's nothing to worry about if this pull request is refused.

I'm only suggesting it because I looked at the code out of curiosity.

Picture in game :
![separator](https://github.com/user-attachments/assets/098a1eba-6610-4b3e-8d71-49843fd77a3e)
